### PR TITLE
feat: add speedometer display

### DIFF
--- a/src/runtime/builder/utils.ts
+++ b/src/runtime/builder/utils.ts
@@ -2,7 +2,7 @@ import { Immutable, type ImmutableArray, type UseDataSource, DataSourceManager, 
 import { sanitizer, richTextUtils } from 'jimu-ui'
 import { replacePlaceholderTextContent } from '../../utils'
 import { ZeroWidthSpace } from '../../consts'
-import { MAX_DATA_SOURCES_PROFILE_ARCADE_CONTENT_PER_PAGE } from 'jimu-core/lib/constants'
+import { MAX_DATA_SOURCES_PROFILE_ARCADE_CONTENT_PER_PAGE } from 'jimu-core/constants'
 export { getExpressionParts } from '../../utils'
 export const DATA_SOURCE_ID_REGEXP = /data-dsid=\"(((?![\=|\>|\"]).)*)[\"\>|"\s)]/gm
 

--- a/src/runtime/displayer.tsx
+++ b/src/runtime/displayer.tsx
@@ -2,6 +2,7 @@ import { React, polished, type IMExpression, ExpressionResolverComponent, expres
 import { DownDoubleOutlined } from 'jimu-icons/outlined/directional/down-double'
 import { styled, useTheme } from 'jimu-theme'
 import { RichTextDisplayer, type RichTextDisplayerProps, Scrollable, type ScrollableRefProps, type StyleSettings, type StyleState, styleUtils } from 'jimu-ui'
+import { Speedometer } from './speedometer'
 
 const LeaveDelay = 500
 
@@ -113,6 +114,11 @@ export function Displayer(props: DisplayerProps): React.ReactElement {
   const isTextTooltip = expressionUtils.isSingleStringExpression(tooltip as any)
   const [tooltipText, setTooltipText] = React.useState('')
 
+  const speed = React.useMemo(() => {
+    const match = value.match(/-?\d+(\.\d+)?/)
+    return match ? parseFloat(match[0]) : null
+  }, [value])
+
   const [fadeLength, setFadeLength] = React.useState('24px')
   const [bottoming, setBottoming] = React.useState(false)
   const [scrollable, setScrollable] = React.useState(false)
@@ -189,6 +195,7 @@ export function Displayer(props: DisplayerProps): React.ReactElement {
           placeholder={placeholder}
         />
       </Scrollable>
+      {speed !== null && <Speedometer value={speed} />}
       {showFade && scrollable && !bottoming && <div className='text-fade text-fade-bottom'>
         <span className='arrow arrow-bottom rounded-circle mr-1'>
           <DownDoubleOutlined className='bounce' color={theme?.ref.palette?.black} />

--- a/src/runtime/speedometer.tsx
+++ b/src/runtime/speedometer.tsx
@@ -1,0 +1,21 @@
+import { React } from 'jimu-core'
+
+export interface SpeedometerProps {
+  value: number
+  min?: number
+  max?: number
+}
+
+export const Speedometer = ({ value, min = 0, max = 40 }: SpeedometerProps): React.ReactElement => {
+  const ratio = Math.max(0, Math.min(1, (value - min) / (max - min)))
+  const angle = ratio * 180
+  return (
+    <div className='speedometer' style={{ width: '100%', display: 'flex', justifyContent: 'center', marginTop: 8 }}>
+      <svg viewBox='0 0 100 60' style={{ width: '100%', maxWidth: 200 }}>
+        <path d='M10 50 A40 40 0 0 1 90 50' fill='none' stroke='#ccc' strokeWidth={5} />
+        <line x1={50} y1={50} x2={50} y2={15} stroke='red' strokeWidth={2} transform={`rotate(${angle} 50 50)`} />
+        <text x={50} y={58} textAnchor='middle' fontSize={10}>{value.toFixed(0)} knt</text>
+      </svg>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- add a simple SVG-based speedometer component
- display speedometer beside rich text based on numeric value
- fix builder utils import for jimu-core constants

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b1e8063f08833092039dc3713f6752