### PR TITLE
feat: add speedometer display

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -17,6 +17,9 @@ export interface Config {
   text: string
   style?: Style
   tooltip?: Expression
+  showSpeedometer?: boolean
+  speedometerGaugeColor?: string
+  speedometerNeedleColor?: string
 }
 
 export type IMConfig = ImmutableObject<Config>

--- a/src/runtime/builder/utils.ts
+++ b/src/runtime/builder/utils.ts
@@ -1,8 +1,8 @@
 import { Immutable, type ImmutableArray, type UseDataSource, DataSourceManager, dataSourceUtils, type IMArcadeContentConfigMap, arcadeContentUtils, getAppStore, appActions } from 'jimu-core'
+import { MAX_DATA_SOURCES_PROFILE_ARCADE_CONTENT_PER_PAGE } from 'jimu-core/constants'
 import { sanitizer, richTextUtils } from 'jimu-ui'
 import { replacePlaceholderTextContent } from '../../utils'
 import { ZeroWidthSpace } from '../../consts'
-import { MAX_DATA_SOURCES_PROFILE_ARCADE_CONTENT_PER_PAGE } from 'jimu-core/lib/constants'
 export { getExpressionParts } from '../../utils'
 export const DATA_SOURCE_ID_REGEXP = /data-dsid=\"(((?![\=|\>|\"]).)*)[\"\>|"\s)]/gm
 

--- a/src/runtime/displayer.tsx
+++ b/src/runtime/displayer.tsx
@@ -2,6 +2,7 @@ import { React, polished, type IMExpression, ExpressionResolverComponent, expres
 import { DownDoubleOutlined } from 'jimu-icons/outlined/directional/down-double'
 import { styled, useTheme } from 'jimu-theme'
 import { RichTextDisplayer, type RichTextDisplayerProps, Scrollable, type ScrollableRefProps, type StyleSettings, type StyleState, styleUtils } from 'jimu-ui'
+import { Speedometer } from './speedometer'
 
 const LeaveDelay = 500
 
@@ -10,6 +11,9 @@ export type DisplayerProps = Omit<RichTextDisplayerProps, 'sanitize'> & {
   wrap?: boolean
   dynamicStyleConfig?: IMDynamicStyleConfig
   onArcadeChange?: (style: React.CSSProperties) => void
+  showSpeedometer?: boolean
+  speedometerGaugeColor?: string
+  speedometerNeedleColor?: string
 }
 
 const Root = styled('div')<StyleState<{ wrap: boolean, fadeLength: string }>>(({ theme, styleState }) => {
@@ -103,6 +107,9 @@ export function Displayer(props: DisplayerProps): React.ReactElement {
     tooltip,
     dynamicStyleConfig,
     onArcadeChange,
+    showSpeedometer = true,
+    speedometerGaugeColor,
+    speedometerNeedleColor,
     ...others
   } = props
 
@@ -112,6 +119,13 @@ export function Displayer(props: DisplayerProps): React.ReactElement {
   const rootRef = React.useRef<HTMLDivElement>()
   const isTextTooltip = expressionUtils.isSingleStringExpression(tooltip as any)
   const [tooltipText, setTooltipText] = React.useState('')
+
+  const speed = React.useMemo(() => {
+    const match = value.match(/-?\d+(\.\d+)?/)
+    return match ? parseFloat(match[0]) : null
+  }, [value])
+
+  const showGauge = React.useMemo(() => showSpeedometer && speed !== null, [showSpeedometer, speed])
 
   const [fadeLength, setFadeLength] = React.useState('24px')
   const [bottoming, setBottoming] = React.useState(false)
@@ -181,13 +195,22 @@ export function Displayer(props: DisplayerProps): React.ReactElement {
   return (
     <Root styleState={{ wrap, fadeLength }} title={tooltipText} onMouseEnter={handleEnter} onMouseLeave={delayLeave} ref={rootRef} {...others}>
       <Scrollable ref={syncScrollState} version={version}>
-        <RichTextDisplayer
-          widgetId={widgetId}
-          repeatedDataSource={repeatedDataSource}
-          useDataSources={useDataSources}
-          value={value}
-          placeholder={placeholder}
-        />
+        {!showGauge && (
+          <RichTextDisplayer
+            widgetId={widgetId}
+            repeatedDataSource={repeatedDataSource}
+            useDataSources={useDataSources}
+            value={value}
+            placeholder={placeholder}
+          />
+        )}
+        {showGauge && (
+          <Speedometer
+            value={speed as number}
+            gaugeColor={speedometerGaugeColor}
+            needleColor={speedometerNeedleColor}
+          />
+        )}
       </Scrollable>
       {showFade && scrollable && !bottoming && <div className='text-fade text-fade-bottom'>
         <span className='arrow arrow-bottom rounded-circle mr-1'>

--- a/src/runtime/speedometer.tsx
+++ b/src/runtime/speedometer.tsx
@@ -1,0 +1,40 @@
+import { React } from 'jimu-core'
+
+export interface SpeedometerProps {
+  value: number
+  min?: number
+  max?: number
+  gaugeColor?: string
+  needleColor?: string
+}
+
+export const Speedometer = ({ value, min = 0, max = 40, gaugeColor = '#ccc', needleColor = 'red' }: SpeedometerProps): React.ReactElement => {
+  const ratio = Math.max(0, Math.min(1, (value - min) / (max - min)))
+  const angle = ratio * 180 - 90
+  const ticks = Array.from({ length: 5 }).map((_, i) => {
+    const tickAngle = i * 45 - 90
+    return (
+      <line
+        key={i}
+        x1={50}
+        y1={50}
+        x2={50}
+        y2={40}
+        stroke={gaugeColor}
+        strokeWidth={1}
+        transform={`rotate(${tickAngle} 50 50)`}
+      />
+    )
+  })
+  return (
+    <div className='speedometer' style={{ width: '100%', display: 'flex', justifyContent: 'center', marginTop: 8 }}>
+      <svg viewBox='0 0 100 70' style={{ width: '100%', maxWidth: 200 }}>
+        <path d='M10 50 A40 40 0 0 1 90 50' fill='none' stroke={gaugeColor} strokeWidth={8} strokeLinecap='round' />
+        {ticks}
+        <line x1={50} y1={50} x2={50} y2={20} stroke={needleColor} strokeWidth={2} transform={`rotate(${angle} 50 50)`} />
+        <circle cx={50} cy={50} r={3} fill={needleColor} />
+        <text x={50} y={66} textAnchor='middle' fontSize={12} fill='currentColor'>{value.toFixed(0)} knt</text>
+      </svg>
+    </div>
+  )
+}

--- a/src/runtime/widget.tsx
+++ b/src/runtime/widget.tsx
@@ -314,6 +314,9 @@ const Widget = (props: AllWidgetProps<IMConfig>): React.ReactElement => {
         dynamicStyleConfig={arcade}
         onArcadeChange={handleArcadeChange}
         repeatedDataSource={repeatedDataSource as RepeatedDataSource}
+        showSpeedometer={config.showSpeedometer ?? true}
+        speedometerGaugeColor={config.speedometerGaugeColor}
+        speedometerNeedleColor={config.speedometerNeedleColor}
       />
       <Popper open={isDynamicStyleSettingActive} offsetOptions={[0, 4]} css={getDynamicPreviewStyle()} autoUpdate shiftOptions={shiftOptions}
         flipOptions={flipOptions} placement='right-start' reference={rootRef} >

--- a/src/setting/setting.tsx
+++ b/src/setting/setting.tsx
@@ -4,6 +4,7 @@ import { SettingRow, SettingSection } from 'jimu-ui/advanced/setting-components'
 import { RichTextFormatKeys, type Editor } from 'jimu-ui/advanced/rich-text-editor'
 import type { IMConfig } from '../config'
 import { Switch, defaultMessages as jimuUiMessage, richTextUtils, TextArea } from 'jimu-ui'
+import { ColorPicker } from 'jimu-ui/basic/color-picker'
 import { DataSourceSelector } from 'jimu-ui/advanced/data-source-selector'
 import defaultMessages from './translations/default'
 import { ExpressionInput, ExpressionInputType } from 'jimu-ui/advanced/expression-builder'
@@ -45,6 +46,9 @@ const Setting = (props: SettingProps): React.ReactElement => {
   const placeholderEditable = getAppStore().getState().appStateInBuilder?.appInfo?.type === 'Web Experience Template'
   const style = propConfig.style
   const wrap = style?.wrap ?? true
+  const showSpeedometer = propConfig.showSpeedometer ?? true
+  const gaugeColor = propConfig.speedometerGaugeColor ?? '#ccc'
+  const needleColor = propConfig.speedometerNeedleColor ?? 'red'
   const enableDynamicStyle = style?.enableDynamicStyle ?? false
   const dynamicStyleConfig = style?.dynamicStyleConfig
   const text = propConfig.text
@@ -124,6 +128,27 @@ const Setting = (props: SettingProps): React.ReactElement => {
     onSettingChange({
       id,
       config: propConfig.setIn(['style', 'wrap'], !wrap)
+    })
+  }
+
+  const toggleSpeedometer = (): void => {
+    onSettingChange({
+      id,
+      config: propConfig.set('showSpeedometer', !showSpeedometer)
+    })
+  }
+
+  const handleGaugeColorChange = (color: string): void => {
+    onSettingChange({
+      id,
+      config: propConfig.set('speedometerGaugeColor', color)
+    })
+  }
+
+  const handleNeedleColorChange = (color: string): void => {
+    onSettingChange({
+      id,
+      config: propConfig.set('speedometerNeedleColor', color)
     })
   }
 
@@ -214,6 +239,17 @@ const Setting = (props: SettingProps): React.ReactElement => {
         {placeholderEditable && <SettingRow flow='wrap' label={translate('placeholder')}>
           <TextArea aria-label={translate('placeholder')} defaultValue={placeholderText} onAcceptValue={handlePlaceholderTextChange}></TextArea>
         </SettingRow>}
+        <SettingRow flow='no-wrap' tag='label' label={translate('showSpeedometer')}>
+          <Switch checked={showSpeedometer} onChange={toggleSpeedometer} />
+        </SettingRow>
+        {showSpeedometer && <>
+          <SettingRow flow='no-wrap' label={translate('gaugeColor')}>
+            <ColorPicker color={gaugeColor} onChange={handleGaugeColorChange} />
+          </SettingRow>
+          <SettingRow flow='no-wrap' label={translate('needleColor')}>
+            <ColorPicker color={needleColor} onChange={handleNeedleColorChange} />
+          </SettingRow>
+        </>}
 
       </SettingSection>
 

--- a/src/setting/translations/default.ts
+++ b/src/setting/translations/default.ts
@@ -1,3 +1,7 @@
 export default {
-  verticalAlignment: 'Vertical alignment'
+  verticalAlignment: 'Vertical alignment',
+  speedometer: 'Speedometer',
+  showSpeedometer: 'Show speedometer',
+  gaugeColor: 'Gauge color',
+  needleColor: 'Needle color'
 }


### PR DESCRIPTION
## Summary
- add switch to enable speedometer display
- render speedometer inside textbox content and parse numeric speed
- allow widget config to control speedometer visibility
- allow color customization for gauge and needle
- hide numeric value in textbox when speedometer is shown
- improve gauge visuals with ticks and centered needle
- fix settings panel color picker import

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b1e8063f08833092039dc3713f6752