### PR TITLE
feat: add speedometer display

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -17,6 +17,18 @@ export interface Config {
   text: string
   style?: Style
   tooltip?: Expression
+  showSpeedometer?: boolean
+  speedometerGaugeColor?: string
+  speedometerNeedleColor?: string
+  speedometerTextColor?: string
+  speedometerTextFont?: string
+  speedometerTextSize?: number
+  speedometerTextBold?: boolean
+  speedometerTickColor?: string
+  speedometerTickFont?: string
+  speedometerTickSize?: number
+  speedometerTickBold?: boolean
+  speedometerPadding?: number
 }
 
 export type IMConfig = ImmutableObject<Config>

--- a/src/runtime/builder/utils.ts
+++ b/src/runtime/builder/utils.ts
@@ -1,8 +1,18 @@
-import { Immutable, type ImmutableArray, type UseDataSource, DataSourceManager, dataSourceUtils, type IMArcadeContentConfigMap, arcadeContentUtils, getAppStore, appActions } from 'jimu-core'
+import {
+  Immutable,
+  type ImmutableArray,
+  type UseDataSource,
+  DataSourceManager,
+  dataSourceUtils,
+  type IMArcadeContentConfigMap,
+  arcadeContentUtils,
+  getAppStore,
+  appActions,
+  MAX_DATA_SOURCES_PROFILE_ARCADE_CONTENT_PER_PAGE
+} from 'jimu-core'
 import { sanitizer, richTextUtils } from 'jimu-ui'
 import { replacePlaceholderTextContent } from '../../utils'
 import { ZeroWidthSpace } from '../../consts'
-import { MAX_DATA_SOURCES_PROFILE_ARCADE_CONTENT_PER_PAGE } from 'jimu-core/lib/constants'
 export { getExpressionParts } from '../../utils'
 export const DATA_SOURCE_ID_REGEXP = /data-dsid=\"(((?![\=|\>|\"]).)*)[\"\>|"\s)]/gm
 

--- a/src/runtime/displayer.tsx
+++ b/src/runtime/displayer.tsx
@@ -2,6 +2,7 @@ import { React, polished, type IMExpression, ExpressionResolverComponent, expres
 import { DownDoubleOutlined } from 'jimu-icons/outlined/directional/down-double'
 import { styled, useTheme } from 'jimu-theme'
 import { RichTextDisplayer, type RichTextDisplayerProps, Scrollable, type ScrollableRefProps, type StyleSettings, type StyleState, styleUtils } from 'jimu-ui'
+import { Speedometer } from './speedometer'
 
 const LeaveDelay = 500
 
@@ -10,6 +11,18 @@ export type DisplayerProps = Omit<RichTextDisplayerProps, 'sanitize'> & {
   wrap?: boolean
   dynamicStyleConfig?: IMDynamicStyleConfig
   onArcadeChange?: (style: React.CSSProperties) => void
+  showSpeedometer?: boolean
+  speedometerGaugeColor?: string
+  speedometerNeedleColor?: string
+  speedometerTextColor?: string
+  speedometerTextFont?: string
+  speedometerTextSize?: number
+  speedometerTextBold?: boolean
+  speedometerTickColor?: string
+  speedometerTickFont?: string
+  speedometerTickSize?: number
+  speedometerTickBold?: boolean
+  speedometerPadding?: number
 }
 
 const Root = styled('div')<StyleState<{ wrap: boolean, fadeLength: string }>>(({ theme, styleState }) => {
@@ -103,6 +116,18 @@ export function Displayer(props: DisplayerProps): React.ReactElement {
     tooltip,
     dynamicStyleConfig,
     onArcadeChange,
+    showSpeedometer = true,
+    speedometerGaugeColor,
+    speedometerNeedleColor,
+    speedometerTextColor,
+    speedometerTextFont,
+    speedometerTextSize,
+    speedometerTextBold,
+    speedometerTickColor,
+    speedometerTickFont,
+    speedometerTickSize,
+    speedometerTickBold,
+    speedometerPadding,
     ...others
   } = props
 
@@ -112,6 +137,13 @@ export function Displayer(props: DisplayerProps): React.ReactElement {
   const rootRef = React.useRef<HTMLDivElement>()
   const isTextTooltip = expressionUtils.isSingleStringExpression(tooltip as any)
   const [tooltipText, setTooltipText] = React.useState('')
+
+  const speed = React.useMemo(() => {
+    const match = value.match(/-?\d+(\.\d+)?/)
+    return match ? parseFloat(match[0]) : null
+  }, [value])
+
+  const showGauge = React.useMemo(() => showSpeedometer && speed !== null, [showSpeedometer, speed])
 
   const [fadeLength, setFadeLength] = React.useState('24px')
   const [bottoming, setBottoming] = React.useState(false)
@@ -181,13 +213,31 @@ export function Displayer(props: DisplayerProps): React.ReactElement {
   return (
     <Root styleState={{ wrap, fadeLength }} title={tooltipText} onMouseEnter={handleEnter} onMouseLeave={delayLeave} ref={rootRef} {...others}>
       <Scrollable ref={syncScrollState} version={version}>
-        <RichTextDisplayer
-          widgetId={widgetId}
-          repeatedDataSource={repeatedDataSource}
-          useDataSources={useDataSources}
-          value={value}
-          placeholder={placeholder}
-        />
+        {!showGauge && (
+          <RichTextDisplayer
+            widgetId={widgetId}
+            repeatedDataSource={repeatedDataSource}
+            useDataSources={useDataSources}
+            value={value}
+            placeholder={placeholder}
+          />
+        )}
+        {showGauge && (
+          <Speedometer
+            value={speed as number}
+            gaugeColor={speedometerGaugeColor}
+            needleColor={speedometerNeedleColor}
+            labelColor={speedometerTextColor}
+            labelFontFamily={speedometerTextFont}
+            labelFontSize={speedometerTextSize}
+            labelBold={speedometerTextBold}
+            tickColor={speedometerTickColor}
+            tickFontFamily={speedometerTickFont}
+            tickFontSize={speedometerTickSize}
+            tickBold={speedometerTickBold}
+            padding={speedometerPadding}
+          />
+        )}
       </Scrollable>
       {showFade && scrollable && !bottoming && <div className='text-fade text-fade-bottom'>
         <span className='arrow arrow-bottom rounded-circle mr-1'>

--- a/src/runtime/speedometer.tsx
+++ b/src/runtime/speedometer.tsx
@@ -1,0 +1,117 @@
+import { React } from 'jimu-core'
+
+export interface SpeedometerProps {
+  value: number
+  min?: number
+  max?: number
+  gaugeColor?: string
+  needleColor?: string
+  labelColor?: string
+  labelFontFamily?: string
+  labelFontSize?: number
+  labelBold?: boolean
+  tickColor?: string
+  tickFontFamily?: string
+  tickFontSize?: number
+  tickBold?: boolean
+  padding?: number
+}
+
+export const Speedometer = ({
+  value,
+  min = 0,
+  max = 40,
+  gaugeColor = '#000',
+  needleColor = 'red',
+  labelColor = '#000',
+  labelFontFamily = 'Arial',
+  labelFontSize = 12,
+  labelBold = false,
+  tickColor = '#000',
+  tickFontFamily = 'Arial',
+  tickFontSize = 10,
+  tickBold = false,
+  padding = 0
+}: SpeedometerProps): React.ReactElement => {
+  const ratio = Math.max(0, Math.min(1, (value - min) / (max - min)))
+  const angle = ratio * 180 - 90
+  const ticks = React.useMemo(() => {
+    const count = 4
+    const cx = 100
+    const cy = 100
+    const outer = 90
+    const inner = 82
+    const labelRadius = 65
+    return Array.from({ length: count + 1 }, (_, i) => {
+      const r = i / count
+      const rad = Math.PI - r * Math.PI
+      const cos = Math.cos(rad)
+      const sin = Math.sin(rad)
+      const x1 = cx + outer * cos
+      const y1 = cy - outer * sin
+      const x2 = cx + inner * cos
+      const y2 = cy - inner * sin
+      const lx = cx + labelRadius * cos
+      const ly = cy - labelRadius * sin
+      const label = Math.round(min + (max - min) * r)
+      return { x1, y1, x2, y2, lx, ly, label }
+    })
+  }, [min, max])
+  return (
+    <div className='speedometer' style={{ width: '100%', display: 'flex', justifyContent: 'center', marginTop: 8, padding }}>
+      <svg width='100%' height='100%' viewBox='0 0 200 140' xmlns='http://www.w3.org/2000/svg' aria-label='Gauge icon'>
+        <g fill='none' strokeLinecap='round'>
+          <g stroke={gaugeColor}>
+            <path d='M 10 100 A 90 90 0 0 1 190 100' strokeWidth='4' />
+            <g strokeWidth='4'>
+              {ticks.map((t, i) => (
+                <line key={i} x1={t.x1} y1={t.y1} x2={t.x2} y2={t.y2} />
+              ))}
+            </g>
+            <g strokeWidth='2'>
+              <line x1='100' y1='88' x2='100' y2='82' />
+              <line x1='112' y1='100' x2='118' y2='100' />
+              <line x1='100' y1='112' x2='100' y2='118' />
+              <line x1='88' y1='100' x2='82' y2='100' />
+              <line x1='108' y1='92' x2='112' y2='88' />
+              <line x1='108' y1='108' x2='112' y2='112' />
+              <line x1='92' y1='108' x2='88' y2='112' />
+              <line x1='92' y1='92' x2='88' y2='88' />
+            </g>
+            {ticks.map((t, i) => (
+              <text
+                key={`label-${i}`}
+                x={t.lx}
+                y={t.ly}
+                textAnchor='middle'
+                alignmentBaseline='middle'
+                fontSize={tickFontSize}
+                fontFamily={tickFontFamily}
+                fontWeight={tickBold ? 'bold' : 'normal'}
+                fill={tickColor}
+              >
+                {t.label}
+              </text>
+            ))}
+          </g>
+          <g stroke={needleColor} strokeWidth='4'>
+            <circle cx='100' cy='100' r='12' fill='none' />
+            <line x1='100' y1='100' x2='100' y2='70' transform={`rotate(${angle} 100 100)`} />
+          </g>
+        </g>
+        <text
+          x='100'
+          y='135'
+          textAnchor='middle'
+          fontSize={labelFontSize}
+          fontFamily={labelFontFamily}
+          fontWeight={labelBold ? 'bold' : 'normal'}
+          fill={labelColor}
+        >
+          {value.toFixed(0)} knt
+        </text>
+      </svg>
+    </div>
+  )
+}
+

--- a/src/runtime/widget.tsx
+++ b/src/runtime/widget.tsx
@@ -314,6 +314,18 @@ const Widget = (props: AllWidgetProps<IMConfig>): React.ReactElement => {
         dynamicStyleConfig={arcade}
         onArcadeChange={handleArcadeChange}
         repeatedDataSource={repeatedDataSource as RepeatedDataSource}
+        showSpeedometer={config.showSpeedometer ?? true}
+        speedometerGaugeColor={config.speedometerGaugeColor}
+        speedometerNeedleColor={config.speedometerNeedleColor}
+        speedometerTextColor={config.speedometerTextColor}
+        speedometerTextFont={config.speedometerTextFont}
+        speedometerTextSize={config.speedometerTextSize}
+        speedometerTextBold={config.speedometerTextBold}
+        speedometerTickColor={config.speedometerTickColor}
+        speedometerTickFont={config.speedometerTickFont}
+        speedometerTickSize={config.speedometerTickSize}
+        speedometerTickBold={config.speedometerTickBold}
+        speedometerPadding={config.speedometerPadding}
       />
       <Popper open={isDynamicStyleSettingActive} offsetOptions={[0, 4]} css={getDynamicPreviewStyle()} autoUpdate shiftOptions={shiftOptions}
         flipOptions={flipOptions} placement='right-start' reference={rootRef} >

--- a/src/setting/setting.tsx
+++ b/src/setting/setting.tsx
@@ -3,7 +3,8 @@ import { builderAppSync, type AllWidgetSettingProps } from 'jimu-for-builder'
 import { SettingRow, SettingSection } from 'jimu-ui/advanced/setting-components'
 import { RichTextFormatKeys, type Editor } from 'jimu-ui/advanced/rich-text-editor'
 import type { IMConfig } from '../config'
-import { Switch, defaultMessages as jimuUiMessage, richTextUtils, TextArea } from 'jimu-ui'
+import { Switch, defaultMessages as jimuUiMessage, richTextUtils, TextArea, TextInput } from 'jimu-ui'
+import { ThemeColorPicker } from 'jimu-ui/basic/color-picker'
 import { DataSourceSelector } from 'jimu-ui/advanced/data-source-selector'
 import defaultMessages from './translations/default'
 import { ExpressionInput, ExpressionInputType } from 'jimu-ui/advanced/expression-builder'
@@ -45,6 +46,30 @@ const Setting = (props: SettingProps): React.ReactElement => {
   const placeholderEditable = getAppStore().getState().appStateInBuilder?.appInfo?.type === 'Web Experience Template'
   const style = propConfig.style
   const wrap = style?.wrap ?? true
+  const showSpeedometer = propConfig.showSpeedometer ?? true
+  const gaugeColor = propConfig.speedometerGaugeColor ?? '#ccc'
+  const needleColor = propConfig.speedometerNeedleColor ?? 'red'
+  const tickFont = propConfig.speedometerTickFont ?? 'Arial'
+  const tickSize = propConfig.speedometerTickSize ?? 10
+  const tickBold = propConfig.speedometerTickBold ?? false
+  const tickColor = propConfig.speedometerTickColor ?? '#000'
+  const textFont = propConfig.speedometerTextFont ?? 'Arial'
+  const textSize = propConfig.speedometerTextSize ?? 12
+  const textBold = propConfig.speedometerTextBold ?? false
+  const textColor = propConfig.speedometerTextColor ?? '#000'
+  const padding = propConfig.speedometerPadding ?? 0
+
+  const [localFont, setLocalFont] = React.useState(textFont)
+  const [localSize, setLocalSize] = React.useState(String(textSize))
+  const [localTickFont, setLocalTickFont] = React.useState(tickFont)
+  const [localTickSize, setLocalTickSize] = React.useState(String(tickSize))
+  const [localPadding, setLocalPadding] = React.useState(String(padding))
+
+  React.useEffect(() => { setLocalFont(textFont) }, [textFont])
+  React.useEffect(() => { setLocalSize(String(textSize)) }, [textSize])
+  React.useEffect(() => { setLocalTickFont(tickFont) }, [tickFont])
+  React.useEffect(() => { setLocalTickSize(String(tickSize)) }, [tickSize])
+  React.useEffect(() => { setLocalPadding(String(padding)) }, [padding])
   const enableDynamicStyle = style?.enableDynamicStyle ?? false
   const dynamicStyleConfig = style?.dynamicStyleConfig
   const text = propConfig.text
@@ -124,6 +149,104 @@ const Setting = (props: SettingProps): React.ReactElement => {
     onSettingChange({
       id,
       config: propConfig.setIn(['style', 'wrap'], !wrap)
+    })
+  }
+
+  const toggleSpeedometer = (): void => {
+    onSettingChange({
+      id,
+      config: propConfig.set('showSpeedometer', !showSpeedometer)
+    })
+  }
+
+  const handleGaugeColorChange = (color: string): void => {
+    onSettingChange({
+      id,
+      config: propConfig.set('speedometerGaugeColor', color)
+    })
+  }
+
+  const handleNeedleColorChange = (color: string): void => {
+    onSettingChange({
+      id,
+      config: propConfig.set('speedometerNeedleColor', color)
+    })
+  }
+
+  const handleTickColorChange = (color: string): void => {
+    onSettingChange({
+      id,
+      config: propConfig.set('speedometerTickColor', color)
+    })
+  }
+
+  const handleTextColorChange = (color: string): void => {
+    onSettingChange({
+      id,
+      config: propConfig.set('speedometerTextColor', color)
+    })
+  }
+
+  const handlePaddingAccept = (value: number | string): void => {
+    const num = typeof value === 'number' ? value : parseInt(value)
+    if (!isNaN(num)) {
+      setLocalPadding(String(num))
+      onSettingChange({
+        id,
+        config: propConfig.set('speedometerPadding', num)
+      })
+    }
+  }
+
+  const handleTextFontAccept = (value: string): void => {
+    setLocalFont(value)
+    onSettingChange({
+      id,
+      config: propConfig.set('speedometerTextFont', value)
+    })
+  }
+
+  const handleTextSizeAccept = (value: number | string): void => {
+    const num = typeof value === 'number' ? value : parseInt(value)
+    if (!isNaN(num)) {
+      setLocalSize(String(num))
+      onSettingChange({
+        id,
+        config: propConfig.set('speedometerTextSize', num)
+      })
+    }
+  }
+
+  const toggleTextBold = (): void => {
+    onSettingChange({
+      id,
+      config: propConfig.set('speedometerTextBold', !textBold)
+    })
+  }
+
+  const handleTickFontAccept = (value: string): void => {
+    setLocalTickFont(value)
+    onSettingChange({
+      id,
+      config: propConfig.set('speedometerTickFont', value)
+    })
+  }
+
+  const handleTickSizeAccept = (value: number | string): void => {
+    const num = typeof value === 'number' ? value : parseInt(value)
+    if (!isNaN(num)) {
+      setLocalTickSize(String(num))
+      onSettingChange({
+        id,
+        config: propConfig.set('speedometerTickSize', num)
+      })
+    }
+  }
+
+  const toggleTickBold = (): void => {
+    onSettingChange({
+      id,
+      config: propConfig.set('speedometerTickBold', !tickBold)
     })
   }
 
@@ -214,6 +337,44 @@ const Setting = (props: SettingProps): React.ReactElement => {
         {placeholderEditable && <SettingRow flow='wrap' label={translate('placeholder')}>
           <TextArea aria-label={translate('placeholder')} defaultValue={placeholderText} onAcceptValue={handlePlaceholderTextChange}></TextArea>
         </SettingRow>}
+        <SettingRow flow='no-wrap' tag='label' label={translate('showSpeedometer')}>
+          <Switch checked={showSpeedometer} onChange={toggleSpeedometer} />
+        </SettingRow>
+        {showSpeedometer && <>
+          <SettingRow className='mb-3' flow='no-wrap' label={translate('gaugeColor')}>
+            <ThemeColorPicker value={gaugeColor} onChange={handleGaugeColorChange} />
+          </SettingRow>
+          <SettingRow className='mb-3' flow='no-wrap' label={translate('needleColor')}>
+            <ThemeColorPicker value={needleColor} onChange={handleNeedleColorChange} />
+          </SettingRow>
+          <SettingRow className='mb-3' flow='no-wrap' label={translate('tickColor')}>
+            <ThemeColorPicker value={tickColor} onChange={handleTickColorChange} />
+          </SettingRow>
+          <SettingRow className='mb-3' flow='no-wrap' label={translate('tickFont')}>
+            <TextInput style={{ width: 120 }} value={localTickFont} onChange={(_e, v) => setLocalTickFont(v)} onAcceptValue={handleTickFontAccept} />
+          </SettingRow>
+          <SettingRow className='mb-3' flow='no-wrap' label={translate('tickSize')}>
+            <TextInput style={{ width: 80 }} type='number' value={localTickSize} onChange={(_e, v) => setLocalTickSize(v)} onAcceptValue={handleTickSizeAccept} />
+          </SettingRow>
+          <SettingRow className='mb-3' flow='no-wrap' tag='label' label={translate('tickBold')}>
+            <Switch checked={tickBold} onChange={toggleTickBold} />
+          </SettingRow>
+          <SettingRow className='mb-3' flow='no-wrap' label={translate('textColor')}>
+            <ThemeColorPicker value={textColor} onChange={handleTextColorChange} />
+          </SettingRow>
+          <SettingRow className='mb-3' flow='no-wrap' label={translate('textFont')}>
+            <TextInput style={{ width: 120 }} value={localFont} onChange={(_e, v) => setLocalFont(v)} onAcceptValue={handleTextFontAccept} />
+          </SettingRow>
+          <SettingRow className='mb-3' flow='no-wrap' label={translate('textSize')}>
+            <TextInput style={{ width: 80 }} type='number' value={localSize} onChange={(_e, v) => setLocalSize(v)} onAcceptValue={handleTextSizeAccept} />
+          </SettingRow>
+          <SettingRow className='mb-3' flow='no-wrap' label={translate('gaugePadding')}>
+            <TextInput style={{ width: 80 }} type='number' value={localPadding} onChange={(_e, v) => setLocalPadding(v)} onAcceptValue={handlePaddingAccept} />
+          </SettingRow>
+          <SettingRow className='mb-3' flow='no-wrap' tag='label' label={translate('textBold')}>
+            <Switch checked={textBold} onChange={toggleTextBold} />
+          </SettingRow>
+        </>}
 
       </SettingSection>
 

--- a/src/setting/translations/default.ts
+++ b/src/setting/translations/default.ts
@@ -1,3 +1,16 @@
 export default {
-  verticalAlignment: 'Vertical alignment'
+  verticalAlignment: 'Vertical alignment',
+  speedometer: 'Speedometer',
+  showSpeedometer: 'Show speedometer',
+  gaugeColor: 'Gauge color',
+  needleColor: 'Needle color',
+  tickColor: 'Tick color',
+  tickFont: 'Tick font',
+  tickSize: 'Tick size',
+  tickBold: 'Tick bold',
+  textColor: 'Value color',
+  textFont: 'Value font',
+  textSize: 'Value size',
+  textBold: 'Value bold',
+  gaugePadding: 'Gauge padding'
 }


### PR DESCRIPTION
## Summary
- use theme color pickers for gauge, needle, and value text
- add padding option to control space around the speedometer SVG
- fix settings panel crash by importing ThemeColorPicker from the correct module path
- add tick labels with configurable font, size, weight, and color

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b1e8063f08833092039dc3713f6752